### PR TITLE
Fix Ctrl+F interception

### DIFF
--- a/src/view-browser.js
+++ b/src/view-browser.js
@@ -389,10 +389,6 @@ host.BrowserHost = class {
     _keyHandler(e) {
         if (!e.altKey && !e.shiftKey && (e.ctrlKey || e.metaKey)) {
             switch (e.keyCode) {
-                case 70: // F
-                    this._view.find();
-                    e.preventDefault();
-                    break;
                 case 68: // D
                     this._view.toggleAttributes();
                     e.preventDefault();


### PR DESCRIPTION
This handler prevents default browser search action.
This handler is useless, as it fails with error.
![photo_2019-06-25_17-30-36](https://user-images.githubusercontent.com/15676425/60126209-24374000-9796-11e9-8794-7943af38e788.jpg)
