### PR TITLE
Fixed bug with default coordinates

### DIFF
--- a/source/view-grapher.js
+++ b/source/view-grapher.js
@@ -78,6 +78,8 @@ grapher.Renderer = class {
                 textContainer.setAttribute('transform', 'translate(' + edgeX + ',' + edgeY + ')');
                 edge.width = edgeBox.width;
                 edge.height = edgeBox.height;
+                edge.x = 0;
+                edge.y = 0;
                 edge.labelElement = labelElement;
             }
         }


### PR DESCRIPTION
Now runtime graph is rendering immediately. If user goes to another page and runtime graph has not yet rendered, then we will get an error in console:
![image](https://user-images.githubusercontent.com/57669899/99278824-96ec0400-2840-11eb-82ca-fd286bf867a8.png)
![image](https://user-images.githubusercontent.com/57669899/99279435-49bc6200-2841-11eb-8e8e-43de14be40ab.png)
This is because graph.edges didn't have time to render therefore they dont have x and y properties. 
Setting default coordinates to zero will resolve this problem.
This did not affect previous functionality in any way.